### PR TITLE
Update RedditQueryServiceTests

### DIFF
--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/RedditQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/RedditQueryServiceTests.java
@@ -35,6 +35,7 @@ public class RedditQueryServiceTests {
         this.mockRestServiceServer.expect(requestTo(expectedURL))
                 .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
                 .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("User-Agent", "spring-boot:cs156-team01:f22 (by /u/cgaucho)"))
                 .andRespond(withSuccess(fakeJSONResult, MediaType.APPLICATION_JSON));
         
         String actualResult = redditQueryService.getJSON(subreddit);


### PR DESCRIPTION
In this PR, we update RedditQueryServiceTests and added mutation test coverage for 429 error header.